### PR TITLE
Fix a typo causing issues for git plugin commands

### DIFF
--- a/plugins/git/git.plugin.xsh
+++ b/plugins/git/git.plugin.xsh
@@ -1,7 +1,7 @@
 # functions
 def git_find_branch(*branches):
     """Return the name of the first git branch found from the provided arg list"""
-    if !(commnad git rev-parse --git-dir all>/dev/null).returncode != 0:
+    if !(command git rev-parse --git-dir all>/dev/null).returncode != 0:
         return
     for branch in branches:
         if !(command git show-ref -q --verify refs/heads/@(branch)).returncode == 0:


### PR DESCRIPTION
Calling functions like `git_main_branch()` returns the following output:

```
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
xonsh: subprocess mode: command not found: 'commnad'
commnad: command not found
```

This PR fixes this issue.